### PR TITLE
Center display background images in the mosiac

### DIFF
--- a/src/components/Mosaic.js
+++ b/src/components/Mosaic.js
@@ -10,6 +10,7 @@ const Base = Box.extend`
   align-items: center;
 
   div {
+    background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
     height: 4rem;


### PR DESCRIPTION
The images look a lot better when they're centered.

Before:

![image](https://user-images.githubusercontent.com/607807/32033811-d111d5fe-b9dc-11e7-99e5-1c35c5b9cc57.png)

After:

![image](https://user-images.githubusercontent.com/607807/32033817-d7da39a8-b9dc-11e7-87aa-5dcfc8d884a9.png)
