### PR TITLE
Fix the cloud type warning on build

### DIFF
--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -15,7 +15,7 @@ import theme from '../theme'
 export default () => (
   <Provider theme={theme}>
     <Head><title>Hack Club</title></Head>
-    <Nav style={{ position: 'absolute', top: 0 }} cloud />
+    <Nav style={{ position: 'absolute', top: 0 }} cloud="true" />
     <Bubbles />
     <Stripe />
     <Features />


### PR DESCRIPTION
When running `npm i && npm run dev` before:
![screenshot_2017-11-29_11 53 42](https://user-images.githubusercontent.com/5891442/33396220-b72c971a-d4fc-11e7-8c58-797ca638c6b0.png)

now:
![screenshot_2017-11-29_12 00 23](https://user-images.githubusercontent.com/5891442/33396286-e8b234d4-d4fc-11e7-926c-c638ca6d2b49.png)

