### PR TITLE
Make a couple small clarity improvements

### DIFF
--- a/src/components/Bubbles.js
+++ b/src/components/Bubbles.js
@@ -114,8 +114,8 @@ const Bubbles = ({ children }) => (
         for the students.
       </Title>
       <Subtitle>
-        Hack Clubs are high school clubs where students learn to code and build
-        amazing things together.
+        Hack Club is a nonprofit network of free student-led coding clubs where
+        members learn to code through building things.
       </Subtitle>
       <Flex justify="center" wrap m={-2}>
         <CTA href="/donate" bg="white" color="primary">

--- a/src/components/Bubbles.js
+++ b/src/components/Bubbles.js
@@ -72,7 +72,7 @@ const Cloud = Box.extend`
     box-sizing: content-box;
     border-radius: 8rem;
     box-shadow: 0 0 4rem 4rem rgba(252, 252, 252, 0.95);
-    max-width: 36rem;
+    max-width: 32rem;
     padding: 1rem;
     top: -2rem;
   }
@@ -84,10 +84,7 @@ const Title = Heading.extend.attrs({
   mx: 'auto',
   my: 0,
   color: 'primary'
-})`
-  line-height: 1;
-  max-width: 32rem;
-`
+})`line-height: 1;`
 const Subtitle = Lead.extend.attrs({
   f: [3, 4],
   mt: 3,

--- a/src/components/Stripe.js
+++ b/src/components/Stripe.js
@@ -43,32 +43,33 @@ const StripeContainer = Container.extend.attrs({
 const Headline = Heading.extend.attrs({
   is: 'h2',
   f: 5,
-  mt: 4,
-  mb: 2,
+  mt: 10,
+  mb: 20,
   color: 'primary'
-})`line-height: 1.25;`
+})`line-height: 1.345;`
+
 const Subheadline = Subhead.extend.attrs({
   is: 'h3',
   f: [3, 4],
   mt: 0,
-  mb: 1,
+  mb: 0,
   color: 'muted'
 })`
   font-weight: normal;
-  line-height: 1.5;
+  line-height: 1.345;
 `
 
 export default () => (
   <Stripe id="more">
     <StripeContainer>
       <Headline f={[5, 6]} mt={0}>
-        Hack Club brings <mark>coding clubs</mark>
-        {' to '}
-        <mark>high schools</mark> everywhere.
+        <mark>1% of US high schools. 35 states. 13 countries.</mark>
       </Headline>
       <Subheadline my={0}>
-        We’re starting the <mark>computer science education</mark> students
-        need.
+        <mark>
+          Join the largest community of students building the class they wish
+          they could take.
+        </mark>
       </Subheadline>
     </StripeContainer>
   </Stripe>

--- a/src/components/Stripe.js
+++ b/src/components/Stripe.js
@@ -23,49 +23,42 @@ const Stripe = Flex.extend.attrs({
 `
 
 const StripeContainer = Container.extend.attrs({
-  maxWidth: 48 * 16,
+  maxWidth: 36 * 16,
   p: 4
 })`
   text-align: center;
   z-index: 1;
 
-  h2, h3 {
-    color: ${colors.black};
-  }
   mark {
     background-color: rgba(250, 247, 133, .85);
-    color: ${colors.black};
+    color: ${colors.black} !important;
     padding-left: .25em;
     padding-right: .25em;
   }
 `
 
 const Headline = Heading.extend.attrs({
-  is: 'h2',
-  f: 5,
-  mt: 10,
-  mb: 20,
-  color: 'primary'
-})`line-height: 1.345;`
+  f: [5, 6],
+  mt: 0,
+  mb: 3
+})`line-height: 1.375;`
 
 const Subheadline = Subhead.extend.attrs({
   is: 'h3',
   f: [3, 4],
-  mt: 0,
-  mb: 0,
-  color: 'muted'
+  m: 0
 })`
   font-weight: normal;
-  line-height: 1.345;
+  line-height: 1.375;
 `
 
 export default () => (
   <Stripe id="more">
     <StripeContainer>
-      <Headline f={[5, 6]} mt={0}>
+      <Headline>
         <mark>1% of US high schools. 35 states. 13 countries.</mark>
       </Headline>
-      <Subheadline my={0}>
+      <Subheadline>
         <mark>
           Join the largest community of students building the class they wish
           they could take.


### PR DESCRIPTION
This PR does two things:

1. Reword the leading subtitle to add more detail
2. Change the map section to focus on metrics

I think the page flows much nicer with these changes, despite repeating the metrics again at the bottom of the page.

Here's a screenshot of what it looks like before these changes:

![screenshot-2017-12-19 hack club high school coding clubs 1](https://user-images.githubusercontent.com/992248/34186077-70756580-e4de-11e7-855e-70db05212e82.jpg)

And after:

![screenshot-2017-12-19 hack club high school coding clubs](https://user-images.githubusercontent.com/992248/34186072-5e6c7a04-e4de-11e7-952a-584068b58d66.jpg)
