### PR TITLE
Remove redirects to old workshops

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -4,8 +4,6 @@
 /finder            https://finder.hackclub.com
 /donate            https://legacy.hackclub.com/donate  200
 /slack_invite      https://legacy.hackclub.com/slack_invite  200
-/workshops         https://legacy.hackclub.com/workshops  200
-/workshops/*       https://legacy.hackclub.com/workshops/:splat  200
 /static/js/*       https://legacy.hackclub.com/static/js/:splat  200
 /static/css/*      https://legacy.hackclub.com/static/css/:splat  200
 /static/media/*    https://legacy.hackclub.com/static/media/:splat  200


### PR DESCRIPTION
These aren't needed any longer since #129 has been merged.