### PR TITLE
Change sentence to sound friendlier

### DIFF
--- a/src/pages/workshops/index.js
+++ b/src/pages/workshops/index.js
@@ -139,7 +139,7 @@ export default ({ data: { allMarkdownRemark: { edges } } }) => {
                   style={{ lineHeight: '1.25' }}
                 >
                   Coding is a <Super color="warning">superpower</Super>.<br />
-                  So start building.
+                  So let's start building.
                 </Text>
               </Container>
               <SuperButton


### PR DESCRIPTION
It might be just me, but "So start building" sounded a bit forceful. This changes it to "So let's start building".