### PR TITLE
Add alt attributes to bubbles

### DIFF
--- a/src/components/home/Bubbles.js
+++ b/src/components/home/Bubbles.js
@@ -111,6 +111,7 @@ const Bubbles = ({ children }) => (
           src={`/avatars/${i + 1}.jpg`}
           size={sample([48, 56, 64, 72, 84, 96]) + 'px'}
           key={`a-${n}`}
+          alt=""
         />
       ))}
     </Flex>


### PR DESCRIPTION
All images should have an [alt] attribute: 

https://dequeuniversity.com/rules/axe/2.2/image-alt