### PR TITLE
Add lang attribute to html

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -33,6 +33,7 @@ export default props => (
       <meta name="format-detection" content="telephone=no" />
       <link rel="icon" type="image/x-icon" href="/favicon.ico" />
       <meta name="theme-color" content={colors.primary} />
+      <html lang="en" />
     </Helmet>
     {props.children()}
   </Fragment>


### PR DESCRIPTION
A lang attribute should always be declared on the html element, to help screen readers determine what language to dictate the page in.