### PR TITLE
Improve Bubbles display on large screens

### DIFF
--- a/src/components/home/Bubbles.js
+++ b/src/components/home/Bubbles.js
@@ -106,7 +106,7 @@ LargeButton.link = LargeButton.withComponent(Link)
 const Bubbles = ({ children }) => (
   <Root justify="center" align="center" pt={3} px={[0, 3]}>
     <Flex justify="space-around" wrap pt={2}>
-      {shuffle([...range(92), ...range(92)]).map((i, n) => (
+      {shuffle([...range(92), ...range(92), ...range(92)]).map((i, n) => (
         <Avatar
           src={`/avatars/${i + 1}.jpg`}
           size={sample([48, 56, 64, 72, 84, 96]) + 'px'}


### PR DESCRIPTION
It's a hacky fix, but...

Before:

![2018-02-15-011923_2560x1440_scrot](https://user-images.githubusercontent.com/992248/36249027-4c568d72-11ee-11e8-95e2-424d0a5e0e1d.png)

After:

![2018-02-15-011926_2560x1440_scrot](https://user-images.githubusercontent.com/992248/36249048-57b9a88e-11ee-11e8-8453-06c4c61df136.png)

