### PR TITLE
Add /hack_camp redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,4 +1,5 @@
 /c9                /cloud9_setup
+/hack_camp         /camp
 /repl              /replit/start
 /find              https://finder.hackclub.com
 /finder            https://finder.hackclub.com


### PR DESCRIPTION
Needed because https://camp.hackclub.com is still pointing to `/hack_camp`.