### PR TITLE
Update @hackclub/design-system to 0.0.1-9

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "map-render": "node src/map/render.js"
   },
   "dependencies": {
-    "@hackclub/design-system": "0.0.1-8",
+    "@hackclub/design-system": "^0.0.1-9",
     "axios": "^0.18.0",
     "formik": "^0.11.11",
     "gatsby": "^1.9.222",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,18 @@
 # yarn lockfile v1
 
 
-"@hackclub/design-system@0.0.1-8":
-  version "0.0.1-8"
-  resolved "https://registry.yarnpkg.com/@hackclub/design-system/-/design-system-0.0.1-8.tgz#8e0406fb49c726a18cd898e182bc24f0e90549fd"
+"@hackclub/design-system@^0.0.1-9":
+  version "0.0.1-9"
+  resolved "https://registry.yarnpkg.com/@hackclub/design-system/-/design-system-0.0.1-9.tgz#6e857471fb59eef02cdfd5e0d75c0c7f707a36fb"
   dependencies:
-    lodash "^4.17.4"
-    palx "^1.0.2"
+    lodash "^4.17.5"
+    palx "1.0.2"
     prop-types "^15.6.0"
     react "^16.2.0"
     react-dom "^16.2.0"
     serve "^6.4.9"
-    styled-components "^3.0.2"
-    styled-system "^1.1.1"
+    styled-components "^3.1.6"
+    styled-system "^1.1.4"
 
 "@ndhoule/each@^2.0.1":
   version "2.0.1"
@@ -6944,9 +6944,9 @@ pako@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
 
-palx@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/palx/-/palx-1.0.3.tgz#cb50b42475f249dbc66efc01942d938b025220c6"
+palx@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/palx/-/palx-1.0.2.tgz#5a0f59ac542a6a9dd7422f29ed3a31bab5bfe0c4"
   dependencies:
     chroma-js "^1.2.1"
     micro "^6.1.0"
@@ -9613,7 +9613,7 @@ style-loader@^0.13.0:
   dependencies:
     loader-utils "^1.0.2"
 
-styled-components@^3.0.2:
+styled-components@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.1.6.tgz#9c443146fa82c6659a9f64dd493bf2202480342e"
   dependencies:
@@ -9627,7 +9627,7 @@ styled-components@^3.0.2:
     stylis-rule-sheet "^0.0.7"
     supports-color "^3.2.3"
 
-styled-system@^1.1.1:
+styled-system@^1.1.4:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/styled-system/-/styled-system-1.1.7.tgz#b9b6906aaec41b9c79f40780e07dc39b81fe93fb"
   dependencies:


### PR DESCRIPTION
This fixes the changes to the color scheme that popped up a few days ago:

<img width="946" alt="screenshot 2018-03-03 19 47 53" src="https://user-images.githubusercontent.com/5891442/36972406-cd1510b2-2023-11e8-8ac7-f78b81009dc8.png">
<img width="397" alt="screenshot 2018-03-05 02 42 51" src="https://user-images.githubusercontent.com/5891442/36972407-cd5d20d2-2023-11e8-9bd0-77dcb7212dad.png">
<img width="398" alt="screenshot 2018-03-05 02 42 55" src="https://user-images.githubusercontent.com/5891442/36972408-cd8a0692-2023-11e8-81c6-462303164a44.png">
<img width="322" alt="screenshot 2018-03-05 02 42 59" src="https://user-images.githubusercontent.com/5891442/36972409-cda14708-2023-11e8-98f6-fbf078b13b90.png">
