### PR TITLE
Improve wording of CTA on /start

### DIFF
--- a/src/pages/start.js
+++ b/src/pages/start.js
@@ -131,7 +131,7 @@ export default () => (
     </One>
     <CTAContainer>
       <LargeButton.link to="/apply" inverted f={[3, 4]}>
-        Apply to Hack Club
+        Begin Your Application
       </LargeButton.link>
     </CTAContainer>
     <Two>
@@ -233,7 +233,7 @@ export default () => (
       </Modules>
       <Box align="center" mt={4}>
         <LargeButton.link to="/apply" inverted f={[3, 4]}>
-          Apply + Start Your Club
+          Begin Your Application
         </LargeButton.link>
       </Box>
     </Four>


### PR DESCRIPTION
Before:

<img width="1497" alt="screen shot 2018-03-23 at 12 19 29" src="https://user-images.githubusercontent.com/992248/37849328-80271122-2e94-11e8-977f-6721cb90aca2.png">

After:

<img width="1497" alt="screen shot 2018-03-23 at 12 19 31" src="https://user-images.githubusercontent.com/992248/37849338-8980d0c8-2e94-11e8-9523-e1d43edf561c.png">

Please excuse fonts not loading in screenshots. I feel like "begin your application" feels less intimidating than "apply to Hack Club".