### PR TITLE
Fix Comments polling

### DIFF
--- a/src/components/challenge/Post.js
+++ b/src/components/challenge/Post.js
@@ -12,7 +12,6 @@ import PropTypes from 'prop-types'
 import { Modal, Overlay, CloseButton } from 'components/Modal'
 import Comments from 'components/challenge/Comments'
 import { dt, tinyDt } from 'helpers'
-import { kebabCase } from 'lodash'
 import api from 'api'
 
 const Row = Flex.extend`
@@ -79,7 +78,7 @@ const PostRow = ({
     bg={mine ? 'yellow.0' : 'white'}
     title={mine ? '👑 Your post!' : `${name} posted on ${dt(createdAt)}`}
     py={[2, 3]}
-    id={kebabCase(name)}
+    id={`post-${id}`}
   >
     <UpvoteButton
       bg={upvoted ? 'primary' : 'smoke'}

--- a/src/components/challenge/Posts.js
+++ b/src/components/challenge/Posts.js
@@ -9,17 +9,19 @@ import { includes, isEmpty, get } from 'lodash'
 class Posts extends Component {
   state = { posts: [], upvotes: [], status: 'loading', prevUserId: null }
 
-  componentWillReceiveProps(nextProps) {
+  static getDerivedStateFromProps = (nextProps, prevState) => {
     const { userId } = nextProps
-    const { prevUserId } = this.state
+    const { prevUserId } = prevState
 
-    if (userId === prevUserId) return
+    if (userId === prevUserId) {
+      return {}
+    } else {
+      return { prevUserId: userId }
+    }
+  }
 
-    this.refreshPosts(userId)
-
-    this.setState({
-      prevUserId: userId
-    })
+  componentDidMount() {
+    this.refreshPosts(this.props.userId)
   }
 
   refreshPosts(newUserId) {


### PR DESCRIPTION
Having the Challenge page open previously would poll *every* thread *every* 2 seconds, regardless of if you'd even opened any comments. No more 👍

@MaxWofford, I did my best to fix the user ID issues on Posts but couldn't totally understand the code. Could you take a quick look at my changes and make sure I didn't break something?