### PR TITLE
Improve Workshops site

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,6 @@
 const path = require('path')
 const fs = require('fs')
 const _ = require('lodash')
-const GeoPattern = require('geopattern')
-const { colors } = require('@hackclub/design-system')
 const writeFile = require('fs').writeFile
 const axios = require('axios')
 
@@ -22,13 +20,6 @@ exports.onPreBootstrap = () =>
       console.error(e)
     })
 
-const pattern = (text = 'Hack Club', color = colors.primary) =>
-  GeoPattern.generate(text, { baseColor: color }).toString()
-const writePattern = (path, name) =>
-  fs.writeFile(path, pattern(_.camelCase(name), colors.blue[6]), (err, a) => {
-    if (err) console.error(err)
-  })
-
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
@@ -39,12 +30,6 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     if (!!parsedFilePath.dir && _.includes(fileNode.relativePath, 'README')) {
       const value = `/workshops/${parsedFilePath.dir}`
       createNodeField({ node, name: 'slug', value })
-      createNodeField({ node, name: 'bg', value: `${value}.svg` })
-
-      const dir = './public/workshops'
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir)
-      const path = `./public${_.replace(value, '/lib', '')}.svg`
-      writePattern(path, node.frontmatter.name)
     }
   }
 }

--- a/src/components/Breadcrumbs.js
+++ b/src/components/Breadcrumbs.js
@@ -3,8 +3,7 @@ import styled from 'styled-components'
 import { Flex, Icon, Link as A, theme } from '@hackclub/design-system'
 
 export const BreadcrumbList = styled(Flex.withComponent('ol'))`
-  font-size: ${theme.fontSizes[3]}px;
-  font-weight: bold;
+  font-size: ${theme.fontSizes[2]}px;
   line-height: 1.25;
   list-style: none;
   padding-left: 0;
@@ -36,5 +35,5 @@ export const Breadcrumb = ({ type = 'Thing', position, name, ...props }) => (
   </li>
 )
 export const BreadcrumbDivider = () => (
-  <Icon glyph="view-forward" size={28} color="snow" mx={1} />
+  <Icon glyph="view-forward" size={28} color="muted" mx={1} />
 )

--- a/src/components/MarkdownBody.js
+++ b/src/components/MarkdownBody.js
@@ -104,7 +104,7 @@ const MarkdownBody = styled(Box)`
   code,
   kbd {
     font-family: ${theme.mono};
-    font-size: 100%;
+    font-size: ${theme.fontSizes[2]}px;
     word-break: break-word;
   }
   pre,
@@ -126,7 +126,7 @@ const MarkdownBody = styled(Box)`
   code,
   kbd {
     border-radius: 3px;
-    padding: ${theme.space[1]}px;
+    padding: ${theme.space[1] / 2}px ${theme.space[1]}px;
   }
   kbd {
     background-color: ${theme.colors.gray[8]};
@@ -134,7 +134,7 @@ const MarkdownBody = styled(Box)`
   }
   pre {
     border-radius: ${theme.radius};
-    line-height: 1.375;
+    line-height: 1.5;
     max-width: 100%;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -212,7 +212,7 @@ class Header extends Component {
     const { scrolled, toggled } = this.state
     const baseColor = dark
       ? color || 'white'
-      : color === 'white'
+      : color === 'white' && scrolled
       ? 'black'
       : color
     const toggleColor = dark

--- a/src/components/workshops/Author.js
+++ b/src/components/workshops/Author.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Flex, Link, Avatar } from '@hackclub/design-system'
+import { isEmpty } from 'lodash'
+
+const Mention = styled(Link).attrs({ color: 'inherit' })`
+  display: inline-flex;
+  align-items: center;
+`
+
+const Author = ({ text, ...props }) => {
+  if (isEmpty(text)) return null
+  // This iterates over each word in authorText, finds GitHub usernames (any
+  // text that looks like "@orpheus", and turns them into links.
+  const parsedAuthorText = text.split(' ').map((word, index, arr) => {
+    const matches = word.match(/@(\w+)/)
+    const processedWord = matches ? (
+      <Mention href={`https://github.com/${matches[1]}`} target="_blank" ml={1}>
+        <Avatar src={`https://github.com/${matches[1]}.png`} size={24} mr={1} />
+        {word}
+      </Mention>
+    ) : (
+      word
+    )
+
+    // This pads returned results with spaces, making our final array look the
+    // following:
+    //   [ 'Hack', ' ', 'Club', ' ', 'staff' ]
+    // if last item in array, don't give an extra space
+    return index === arr.length - 1 ? processedWord : [processedWord, ' ']
+  })
+
+  return (
+    <Flex align="center" justify="center" {...props}>
+      By {parsedAuthorText}
+    </Flex>
+  )
+}
+
+export default Author

--- a/src/components/workshops/Carousel.js
+++ b/src/components/workshops/Carousel.js
@@ -32,10 +32,9 @@ const RehackSlider = styled(Slider)`
 `
 
 const CarouselOuter = styled(Flex).attrs({
-  bg: 'smoke',
+  bg: 'snow',
   color: 'black',
-  pt: [2, 3, 4],
-  pb: [3, null, 4],
+  py: [4, 5],
   flexDirection: 'column',
   align: 'center'
 })``
@@ -152,11 +151,7 @@ const LoadedCarousel = (
   emptyProject
 ) => (
   <Fragment>
-    <Flex
-      flexDirection={['column', null, 'row']}
-      align="center"
-      mb={[0, null, 3]}
-    >
+    <Flex flexDirection={['column', null, 'row']} align="center">
       <Heading.h3 fontSize={4} mr={[null, null, 3]}>
         {projectCount} Rehack
         {projectCount !== 1 && 's'}

--- a/src/components/workshops/Track.js
+++ b/src/components/workshops/Track.js
@@ -9,6 +9,7 @@ import {
   theme
 } from '@hackclub/design-system'
 import { Link } from 'gatsby'
+import { workshopTrackDescriptions as descriptions } from 'data.json'
 import { capitalize, map } from 'lodash'
 
 const Root = styled(Box.section)`
@@ -93,26 +94,15 @@ const WorkshopItem = ({
   </Link>
 )
 
-const descriptions = {
-  arduino:
-    'Bring projects from cyberspace to the real world with this small hardware platform.',
-  challenge: 'Supplemental material for Hack Club Challenges.',
-  club: 'Launching your own Hack Club? Here are a few pointers.',
-  experimental:
-    'As is/no warranty. These workshops haven’t been fully tested yet, so we don’t know just will happen if you try building things with them.',
-  misc: 'The odd ones out. Workshops not yet properly categorized.',
-  pi: 'Start building projects on the coolest credit card-sized computer.',
-  retired:
-    'These workshops are no longer maintained. They may contain errors and are not recommended for club use. Here be dragons.',
-  start:
-    'Set out on your journey by building your own website, then move on to multiplayer games and collaborative web apps.'
-}
-
 const Track = ({ name, data, ...props }) => (
-  <Root id={name} py={[3, 4]} {...props}>
+  <Root id={name} py={[3, 4, 5]} {...props}>
     <Container maxWidth={32} align="center" px={3}>
       {name && (
-        <Heading.h2 color="black" fontSize={4} children={capitalize(name)} />
+        <Heading.h2
+          color="black"
+          fontSize={[4, 5]}
+          children={capitalize(name)}
+        />
       )}
       {descriptions[name] && (
         <Text color="slate" fontSize={2} children={descriptions[name]} />

--- a/src/components/workshops/WorkshopSearch.js
+++ b/src/components/workshops/WorkshopSearch.js
@@ -5,18 +5,8 @@ import Track from './search/Track'
 import NoResults from './search/NoResults'
 import Fuse from 'fuse.js'
 import { groupBy, toPairs } from 'lodash'
+import { workshopTrackOrder as groupOrder } from 'data.json'
 
-const groupOrder = [
-  'start',
-  'club',
-  'challenges',
-  'pi',
-  'react',
-  'arduino',
-  'experimental',
-  'misc',
-  'retired'
-]
 const keys = ['node.frontmatter.name', 'node.frontmatter.description']
 
 export default ({ workshops }) => {

--- a/src/data.json
+++ b/src/data.json
@@ -12,9 +12,27 @@
     "country_count": 17,
     "approximate_members": "3K+"
   },
-  "workshopFeedback": {
-    "thoughts": "Overall thoughts?",
-    "improve": "How would you improve this workshop?"
+  "workshopTrackOrder": [
+    "start",
+    "react",
+    "pi",
+    "arduino",
+    "experimental",
+    "misc",
+    "club",
+    "challenge",
+    "retired"
+  ],
+  "workshopTrackDescriptions": {
+    "arduino": "Bring projects from cyberspace to the real world with this small hardware platform.",
+    "challenge": "Supplemental material for Hack Club Challenges.",
+    "club": "Launching your own Hack Club? Here are a few pointers.",
+    "experimental": "As is/no warranty. These workshops haven’t been fully tested yet, so we don’t know just will happen if you try building things with them.",
+    "misc": "The odd ones out. Workshops not yet properly categorized.",
+    "pi": "Start building with the coolest credit card-sized computer.",
+    "retired": "These workshops are no longer maintained. They may contain errors and are not recommended for club use. Here be dragons.",
+    "react": "React.js is a popular open source JavaScript view library built by Facebook.",
+    "start": "Set out on your journey by building your own website, then move on to multiplayer games and collaborative web apps."
   },
   "org": {
     "@context": "http://schema.org",

--- a/src/pages/workshops/index.js
+++ b/src/pages/workshops/index.js
@@ -133,7 +133,6 @@ export const pageQuery = graphql`
         node {
           fields {
             slug
-            bg
           }
           frontmatter {
             name

--- a/src/templates/workshop.js
+++ b/src/templates/workshop.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 import {
   Box,
@@ -21,6 +21,7 @@ import {
   Breadcrumb,
   BreadcrumbDivider
 } from 'components/Breadcrumbs'
+import { Headline } from 'components/Content'
 import MarkdownBody from 'components/MarkdownBody'
 import Author from 'components/workshops/Author'
 import DiscussOnSlack from 'components/DiscussOnSlack'
@@ -46,7 +47,7 @@ const OnlyOnPrint = styled(Box)`
 const Header = styled(Box.withComponent('header'))`
   border-bottom: 1px solid ${theme.colors.smoke};
 
-  h2 {
+  h2:last-of-type {
     font-weight: 400;
   }
 `
@@ -261,9 +262,9 @@ export default ({ data }) => {
               />
               <BreadcrumbDivider />
             </Breadcrumbs>
-            <Heading.h1 fontSize={6} mb={2} children={name} />
+            <Headline mb={2} children={name} />
             <Heading.h2 fontSize={4} children={description} />
-            <Text fontSize={2} color="muted" mt={3} mb={[3, 0]}>
+            <Text fontSize={2} color="muted" my={3}>
               <Author text={author} />
             </Text>
           </Container>
@@ -285,7 +286,7 @@ export default ({ data }) => {
           </Text>
         </Header>
       </OnlyOnPrint>
-      <Body maxWidth={48} p={3} className="invert">
+      <Body maxWidth={48} p={3} mt={3}>
         {!isEmpty(tail(headings)) && (
           <Toc open>
             <TocHeading>

--- a/src/templates/workshop.js
+++ b/src/templates/workshop.js
@@ -6,7 +6,6 @@ import {
   Flex,
   Heading,
   Icon,
-  Image,
   Link as A,
   Section,
   Text,
@@ -22,8 +21,8 @@ import {
   Breadcrumb,
   BreadcrumbDivider
 } from 'components/Breadcrumbs'
-import IconButton from 'components/IconButton'
 import MarkdownBody from 'components/MarkdownBody'
+import Author from 'components/workshops/Author'
 import DiscussOnSlack from 'components/DiscussOnSlack'
 import ShareButton from 'components/ShareButton'
 import Sheet from 'components/Sheet'
@@ -45,22 +44,10 @@ const OnlyOnPrint = styled(Box)`
 `
 
 const Header = styled(Box.withComponent('header'))`
-  li a,
-  h2,
-  p {
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-  }
-`
+  border-bottom: 1px solid ${theme.colors.smoke};
 
-const Name = styled(Heading.h1).attrs({ px: 4, bg: 'white' })`
-  color: black;
-  mix-blend-mode: screen;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.75);
-  clip-path: polygon(4% 0%, 100% 0%, 96% 100%, 0% 100%);
-  display: inline-block;
-  width: min-content;
-  ${theme.mediaQueries.sm} {
-    width: max-content;
+  h2 {
+    font-weight: 400;
   }
 `
 
@@ -93,6 +80,7 @@ const TocHeading = styled(Text.withComponent('summary')).attrs({
 })`
   cursor: pointer;
   line-height: 1;
+  user-select: none;
   &::-webkit-details-marker {
     display: none;
   }
@@ -124,33 +112,6 @@ const Body = styled(Container.withComponent(MarkdownBody))`
 `
 A.link = A.withComponent(Link)
 Section.h = Section.withComponent('header')
-
-const linkAuthor = authorText => {
-  if (isEmpty(authorText)) return null
-  // This iterates over each word in authorText, finds GitHub usernames (any
-  // text that looks like "@orpheus", and turns them into links.
-  const parsedAuthorText = authorText.split(' ').map((word, index, arr) => {
-    const matches = word.match(/@(\w+)/)
-    const processedWord = matches ? (
-      <A
-        href={`https://github.com/${matches[1]}`}
-        target="_blank"
-        color="inherit"
-        children={word}
-      />
-    ) : (
-      word
-    )
-
-    // This pads returned results with spaces, making our final array look the
-    // following:
-    //   [ 'Hack', ' ', 'Club', ' ', 'staff' ]
-    // if last item in array, don't give an extra space
-    return index === arr.length - 1 ? processedWord : [processedWord, ' ']
-  })
-
-  return <Fragment>Created by {parsedAuthorText}</Fragment>
-}
 
 const CardsSection = styled(Box)`
   background-image: linear-gradient(
@@ -286,21 +247,12 @@ export default ({ data }) => {
         {canonical && <link rel="canonical" href={canonical} />}
         <script type="application/ld+json" children={JSON.stringify(schema)} />
       </Helmet>
-      <Nav />
+      <Nav color="slate" />
       <NotOnPrint>
-        <Header
-          bg="accent"
-          color="white"
-          p={0}
-          align="center"
-          style={{
-            backgroundImage: `url('${bg}')`,
-            position: 'relative'
-          }}
-        >
-          <Container pt={[5, 6]} px={2}>
+        <Header color="black" p={0} align="center">
+          <Container pt={[5, 6]} pb={4} px={2}>
             <Breadcrumbs align="center" justify="center" mt={3} mb={2} wrap>
-              <Breadcrumb to="/workshops" name="All Workshops" position={1} />
+              <Breadcrumb to="/workshops" name="Workshops" position={1} />
               <BreadcrumbDivider />
               <Breadcrumb
                 to={`/workshops#${group}`}
@@ -309,74 +261,59 @@ export default ({ data }) => {
               />
               <BreadcrumbDivider />
             </Breadcrumbs>
-            <Name fontSize={6} mb={3} children={name} />
+            <Heading.h1 fontSize={6} mb={2} children={name} />
             <Heading.h2 fontSize={4} children={description} />
-            <Text
-              fontSize={2}
-              caps
-              mt={3}
-              mb={[3, 0]}
-              children={linkAuthor(author)}
-            />
+            <Text fontSize={2} color="muted" mt={3} mb={[3, 0]}>
+              <Author text={author} />
+            </Text>
           </Container>
-          <Flex width={1} px={3} pb={3} justify="center">
-            <IconButton
-              bg="slate"
-              glyph="edit"
-              children="Edit"
-              inverted
-              href={githubEditUrl(slug)}
-              target="_blank"
-              fontSize={2}
-              my={1}
-            />
-          </Flex>
         </Header>
       </NotOnPrint>
-      <OnlyOnPrint p={3}>
-        <Flex align="center" justify="flex-end" my={3}>
-          <Image
-            src="/logo-red.svg"
-            width={`${theme.space[6]}px`}
-            mr={3}
-            alt="Hack Club logo"
-          />
-          <strong>Computer Science Tutorials</strong>
-        </Flex>
-        <Heading.h1 mt={4} mb={3} children={name} />
-        <Heading.h2 fontSize={4} children={description} />
-        <Text color="muted" my={3} children={linkAuthor(author)} />
-        <Text color="muted">
-          You can find this tutorial online at <u>{url}</u>
-        </Text>
+      <OnlyOnPrint>
+        <Header color="black" p={3} pb={4}>
+          <Flex align="center" mb={3}>
+            <Text caps bold>
+              <Text.span color="primary">Hack Club</Text.span> – Computer
+              Science Tutorials
+            </Text>
+          </Flex>
+          <Heading.h1 mt={4} mb={2} children={name} />
+          <Heading.h2 fontSize={4} mb={3} children={description} />
+          <Author text={author} justify="flex-start" />
+          <Text color="muted" mt={1}>
+            Find this tutorial online at <u>{url}</u>
+          </Text>
+        </Header>
       </OnlyOnPrint>
       <Body maxWidth={48} p={3} className="invert">
-        <Toc open>
-          <TocHeading>
-            <Icon glyph="down-caret" size={32} />
-            <Text.span
-              bold
-              caps
-              color="slate"
-              fontSize={2}
-              ml={1}
-              children="Table of Contents"
-            />
-          </TocHeading>
-          <TocList>
-            {tail(headings).map(heading => (
-              <TocItem
-                key={heading.value}
-                pl={theme.space[(heading.depth - 2) * 2]}
-              >
-                <A
-                  href={`#${slugger.slug(heading.value)}`}
-                  children={heading.value}
-                />
-              </TocItem>
-            ))}
-          </TocList>
-        </Toc>
+        {!isEmpty(tail(headings)) && (
+          <Toc open>
+            <TocHeading>
+              <Icon glyph="down-caret" size={32} />
+              <Text.span
+                bold
+                caps
+                color="slate"
+                fontSize={2}
+                ml={1}
+                children="Table of Contents"
+              />
+            </TocHeading>
+            <TocList>
+              {tail(headings).map(heading => (
+                <TocItem
+                  key={heading.value}
+                  pl={theme.space[(heading.depth - 2) * 2]}
+                >
+                  <A
+                    href={`#${slugger.slug(heading.value)}`}
+                    children={heading.value}
+                  />
+                </TocItem>
+              ))}
+            </TocList>
+          </Toc>
+        )}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </Body>
       <CardsSection py={4}>
@@ -435,7 +372,6 @@ export const pageQuery = graphql`
       html
       fields {
         slug
-        bg
       }
       headings {
         depth


### PR DESCRIPTION
Post-Gatsby 2 replacement for #490.

- [x] Remove patterns from page headers
- [x] Add avatars to authors (paired with hackclub/hackclub#1190)
- [x] Create workshop cards service
- [ ] Implement new social tags
- [x] Fix inline code rendering in Markdown
- [x] Remove feedback form
- [x] Redesign only on print
- [x] Hide TOC if no headings
- [ ] Improve design of main workshops page
  - [x] Fix search input positioning
  - [ ] Move deprecated + Challenge to separate page
- [x] Move Club to bottom
- [ ] Revert pattern removal