### PR TITLE
Fix horizontal scrollbar appearing on macOS on /bank

### DIFF
--- a/src/components/bank/Landing.js
+++ b/src/components/bank/Landing.js
@@ -21,7 +21,7 @@ const Slide = styled(Flex).attrs({
   box-shadow: inset 0 0 4rem 4rem rgba(0, 0, 0, 0.5);
   background-position: center;
   background-size: cover;
-  width: 100vw;
+  width: 100%;
   min-height: 100vh;
   position: relative;
   h1 {


### PR DESCRIPTION
When macOS is set to always show scroll bars, `100vw` width is interpreted in Safari and Chrome as 100% of the window width, including scrollbar width. This means that a horizontal scrollbar appears when scrollbars are set to show.

This PR fixes that issue.