### PR TITLE
Add sign in / apply CTA buttons to Bank landing page

### DIFF
--- a/src/components/bank/Landing.js
+++ b/src/components/bank/Landing.js
@@ -5,6 +5,7 @@ import {
   Flex,
   Heading,
   Link as A,
+  Button,
   theme
 } from '@hackclub/design-system'
 import { Lead } from 'components/Content'
@@ -86,6 +87,7 @@ export default () => (
       color="white"
       mt="auto"
       maxWidth={75}
+      style={{ zIndex: 100 }}
     >
       <Fade bottom>
         <Heading.h1 fontSize={[6, 7, 8, 9]}>
@@ -106,6 +108,12 @@ export default () => (
           run world-class hackathons.
         </Lead>
       </Fade>
+      <Flex justify="center" align="center">
+        <Button href="#apply">Apply with your event</Button>
+        <Button href="https://bank.hackclub.com" ml={3} bg="snow" color="black">
+          Sign in
+        </Button>
+      </Flex>
     </Container>
     <ScrollHint />
     <Flex justify={['flex-end']} px={3}>

--- a/src/components/bank/Start.js
+++ b/src/components/bank/Start.js
@@ -62,7 +62,7 @@ Timeline.Step = ({ name, duration, first = false }) => (
 )
 
 export default () => (
-  <Box.section bg="dark" py={[5, 6, 7]}>
+  <Box.section bg="dark" py={[5, 6, 7]} id="apply">
     <Container maxWidth={48} px={3} align="center">
       <Headline color="white" mb={2}>
         Apply for Hack&nbsp;Club Bank.


### PR DESCRIPTION
This addresses #562 and https://github.com/hackclub/bank/issues/203.

Mobile:

![localhost_8000_bank_(iPhone 6_7_8 Plus)](https://user-images.githubusercontent.com/5403917/64074327-93ca1f80-cc5e-11e9-9624-f2f7c07b773f.png)

Desktop:

![localhost_8000_bank_(iPad Pro)](https://user-images.githubusercontent.com/5403917/64074331-96c51000-cc5e-11e9-97df-3a236a874125.png)
