### PR TITLE
Fix too many redirects on /slack

### DIFF
--- a/now.json
+++ b/now.json
@@ -4,7 +4,6 @@
   "trailingSlash": true,
   "redirects": [
     { "source": "/c9/", "destination": "/cloud9_setup/" },
-    { "source": "/slack/", "destination": "/slack/" },
     { "source": "/slack_invite/", "destination": "/slack/" },
     { "source": "/workshops/slack/", "destination": "/slack/" },
     { "source": "/community/", "destination": "/slack/" },


### PR DESCRIPTION
(untested) This allows /slack to be matched by the v3 rewrite rule introduced in #626. https://github.com/hackclub/site/blob/581fdcbc11673bcb29d49403116816400e686305/now.json#L67