### PR TITLE
Change clone url from hackclub/site to /v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Stuff you need installed ahead of time:
 
 Clone it!
 
-    $ git clone https://github.com/hackclub/site
+    $ git clone https://github.com/hackclub/v2.git
 
 Go into the directory!
 


### PR DESCRIPTION
This PR fixes the url in the README. The `git clone` url on the README was not the same as the repo name (which still works, but it's kind of misleading).